### PR TITLE
Fixed KeyError: 'dylib'

### DIFF
--- a/macholibre/parser.py
+++ b/macholibre/parser.py
@@ -1018,7 +1018,7 @@ class Parser():
             value = self.get_string()
 
             if lc_dylibs is not None:  # If created with two-level namespace
-                dylib = sym['dylib']
+                dylib = sym.get('dylib') or 0
 
                 if dylib == 0:
                     dylib = 'SELF_LIBRARY'


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/x/Downloads/Projects/ios-apps-research-2021/exynex/__main__.py", line 34, in <module>
    cli()
  File "/Users/x/Downloads/Projects/ios-apps-research-2021/exynex/__main__.py", line 22, in cli
    cli_commands()
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/Users/x/Downloads/Projects/ios-apps-research-2021/exynex/cli/analyze.py", line 169, in run
    raise e
  File "/Users/x/Downloads/Projects/ios-apps-research-2021/exynex/cli/analyze.py", line 149, in run
    app_main_executable_props = macholibre.parse(f"{app_dir}/{app_executable}")
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/macholibre/__init__.py", line 45, in parse
    return parser.parse(certs=certs)
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/macholibre/parser.py", line 1695, in parse
    self.parse_file()
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/macholibre/parser.py", line 1685, in parse_file
    self.parse_macho(0, self.__output['size'])
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/macholibre/parser.py", line 1631, in parse_macho
    self.parse_imports(offset, size, lc_symtab,
  File "/Users/x/.pyenv/versions/3.9.0/lib/python3.9/site-packages/macholibre/parser.py", line 1021, in parse_imports
    dylib = sym['dylib']
KeyError: 'dylib'
```